### PR TITLE
Fix stack readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ jobs:
         with:
           ghc-version: '8.8.3' # Exact version of ghc to use
           # cabal-version: 'latest'. Omitted, but defalts to 'latest'
+          enable-stack: true
           stack-version: 'latest'
       - run: runhaskell Hello.hs
 ```


### PR DESCRIPTION
Basically without `enable-stack: true` the `stack-version` string has no effect. This is documented below but was missing from the readme example.