### PR TITLE
Leave cabal's http-transport setting on its default

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8733,7 +8733,6 @@ async function cabalConfig() {
             await core.group('Setting up cabal', async () => {
                 await exec_1.exec('cabal', ['user-config', 'update'], { silent: true });
                 const configFile = await cabalConfig();
-                fs.appendFileSync(configFile, 'http-transport: plain-http\n');
                 if (process.platform === 'win32') {
                     fs.appendFileSync(configFile, 'store-dir: C:\\sr\n');
                     core.setOutput('cabal-store', 'C:\\sr');

--- a/src/setup-haskell.ts
+++ b/src/setup-haskell.ts
@@ -34,7 +34,6 @@ async function cabalConfig(): Promise<string> {
       await core.group('Setting up cabal', async () => {
         await exec('cabal', ['user-config', 'update'], {silent: true});
         const configFile = await cabalConfig();
-        fs.appendFileSync(configFile, 'http-transport: plain-http\n');
 
         if (process.platform === 'win32') {
           fs.appendFileSync(configFile, 'store-dir: C:\\sr\n');


### PR DESCRIPTION
@tclem here's a really simple fix.

At some point, setting http-transport to plain-http had been recommended when this code was originally written, particularly for stability in Windows. This doesn't seem to be necessary anymore as all related github issues that I can find have been closed. In addition, I was unaware that cabal supported https repository urls and that its `plain-http` backend doesn't seem to be implemented with support for https.

Since there's no more stability concerns, and every OS image is guaranteed to ship with working system dependencies, like curl, the default here should be changed to match what cabal ships with in the interest of obeying a principle of least surprise.

Fixes #23