### PR TITLE
Rename default branch

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: build-test
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - '**.md'
   pull_request:


### PR DESCRIPTION
This updates the Action to work with the new default branch #25 

I noticed a use of `master` in the `dist` that's built but I think we can ignore that. Other than that I think we are good to go.