### PR TITLE
Allow apt command to fail

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11058,7 +11058,7 @@ async function installTool(tool, version, os) {
     }
     switch (os) {
         case 'linux':
-            await apt(tool, version);
+            await apt(tool, version).catch(() => {});
             if (await isInstalled(tool, version, os))
                 return;
             await ghcup(tool, version, os);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -123,7 +123,7 @@ export async function installTool(
 
   switch (os) {
     case 'linux':
-      await apt(tool, version);
+      await apt(tool, version).catch(() => {});
       if (await isInstalled(tool, version, os)) return;
       await ghcup(tool, version, os);
       break;


### PR DESCRIPTION
Fixes `ghc-8.8.4` support on Linux, since it's not in hvr's PPA repo.