### PR TITLE
Use correct moving tag in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest # or macOS-latest, or windows-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-haskell@v1.1
+      - uses: actions/setup-haskell@v1
       - run: runhaskell Hello.hs
 ```
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest # or macOS-latest, or windows-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-haskell@v1.1
+      - uses: actions/setup-haskell@v1
         with:
           ghc-version: '8.8' # Resolves to the latest point release of GHC 8.8
           cabal-version: '3.0.0.0' # Exact version of Cabal
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest # or macOS-latest, or windows-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-haskell@v1.1
+      - uses: actions/setup-haskell@v1
         with:
           ghc-version: '8.8.3' # Exact version of ghc to use
           # cabal-version: 'latest'. Omitted, but defalts to 'latest'
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Haskell
-        uses: actions/setup-haskell@v1.1
+        uses: actions/setup-haskell@v1
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}


### PR DESCRIPTION
When I first wrote the README examples, I used v1.1 because I assumed it would also be a moving tag, and it was using some features that only came out in the rewrite. However, only the v1 tag is being updated (which seems to be a common practice across all of the setup-x actions).

This fixes the README to use a tag that actually updates so that people don't need to churn through point releases.